### PR TITLE
Update command cooldown message

### DIFF
--- a/src/bot/handlers/command_handler.js
+++ b/src/bot/handlers/command_handler.js
@@ -131,11 +131,11 @@ async function commandHandler(message) {
     const current_command_epoch = Date.now();
     command_cooldown_tracker.set(message.author.id, { last_command_epoch: current_command_epoch });
 
-    const user_is_spamming_commands = current_command_epoch - last_command_epoch_for_user < command_cooldown_in_ms;
+    const user_command_delay = current_command_epoch - last_command_epoch_for_user < command_cooldown_in_ms;
     const user_is_not_a_staff_member = user_permission_level < command_permission_levels.STAFF;
-    if (user_is_spamming_commands && user_is_not_a_staff_member) {
+    if (user_command_delay && user_is_not_a_staff_member) {
         await message.reply({
-            content: 'Stop spamming commands!',
+            content: `**${command}** is on cooldown!`,
         }).catch(console.warn);
         return;
     }

--- a/src/bot/handlers/command_handler.js
+++ b/src/bot/handlers/command_handler.js
@@ -135,7 +135,7 @@ async function commandHandler(message) {
     const user_is_not_a_staff_member = user_permission_level < command_permission_levels.STAFF;
     if (user_triggered_command_cooldown && user_is_not_a_staff_member) {
         await message.reply({
-            content: `**${command}** is on cooldown!`,
+            content: `**${command_name}** is on a cooldown of ${command_cooldown_in_ms}ms!`,
         }).catch(console.warn);
         return;
     }

--- a/src/bot/handlers/command_handler.js
+++ b/src/bot/handlers/command_handler.js
@@ -131,9 +131,9 @@ async function commandHandler(message) {
     const current_command_epoch = Date.now();
     command_cooldown_tracker.set(message.author.id, { last_command_epoch: current_command_epoch });
 
-    const user_command_delay = current_command_epoch - last_command_epoch_for_user < command_cooldown_in_ms;
+    const user_triggered_command_cooldown = current_command_epoch - last_command_epoch_for_user < command_cooldown_in_ms;
     const user_is_not_a_staff_member = user_permission_level < command_permission_levels.STAFF;
-    if (user_command_delay && user_is_not_a_staff_member) {
+    if (user_triggered_command_cooldown && user_is_not_a_staff_member) {
         await message.reply({
             content: `**${command}** is on cooldown!`,
         }).catch(console.warn);


### PR DESCRIPTION
As there are large delays for some commands such as **!identity_token**, the end user being told that they are "spamming commands" while only sending messages a few seconds *(15-20s)* could get frustrating. This PR is meant for the end user to see that the command is on cool-down, and not be told that they are spamming.